### PR TITLE
Fixed typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ Maven:
         <artifactId>GuiUtil</artifactId>
         <version>Tag</version>
     </dependency>
-</dependencies>```
+</dependencies>
+```


### PR DESCRIPTION
Three grave accents denote the opening and closing to a markdown code block, yes, but if the closing three are not on a new line then it is not correctly interpreted and, in fact, does count as a typo.